### PR TITLE
Use pre-compiled protoc from Maven Central

### DIFF
--- a/convert/build.gradle
+++ b/convert/build.gradle
@@ -21,7 +21,9 @@ dependencies {
 }
 
 protobuf {
-
+    protoc {
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
+    }
 }
 
 publishing {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,6 +22,8 @@ dependencies {
 }
 
 protobuf {
-
+    protoc {
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
+    }
 }
 

--- a/proto-examples/build.gradle
+++ b/proto-examples/build.gradle
@@ -15,7 +15,9 @@ dependencies {
 }
 
 protobuf {
-
+    protoc {
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
+    }
 }
 
 publishing {

--- a/proto-options/build.gradle
+++ b/proto-options/build.gradle
@@ -14,7 +14,9 @@ dependencies {
 }
 
 protobuf {
-
+    protoc {
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
+    }
 }
 
 publishing {

--- a/transform/build.gradle
+++ b/transform/build.gradle
@@ -25,7 +25,9 @@ dependencies {
 }
 
 protobuf {
-
+    protoc {
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
+    }
 }
 
 publishing {


### PR DESCRIPTION
The default search for the protoc executable by protobuf-gradle-plugin is not always successful even though the binary is located at /usr/local/bin/protoc. Making use of a precompiled one avoids this:
https://github.com/google/protobuf-gradle-plugin#locate-external-executables